### PR TITLE
Working on a patch for the 'fails to compile on sapelo' bug

### DIFF
--- a/src/ClisbyTree/Fold.hpp
+++ b/src/ClisbyTree/Fold.hpp
@@ -267,7 +267,9 @@ std::pair<Int,Int> RandomPivots(
     assert( c <  d );
     
     int_unif int_u_i ( a, b - Int(1) );
+    int_unif u_int_i ( a, b - Int(1) ); // experimental! maybe bad!
     int_unif int_u_j ( c, d - Int(1) );
+    int_unif u_int_j ( c, d - Int(1) ); // same here!
     
     Int i;
     Int j;


### PR DESCRIPTION
Changed Fold.hpp to include definitions of corresponding identifiers.